### PR TITLE
Add Windows installer script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# Virtual environments
+.venv/
+venv/
+venv-test/
+env/
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log

--- a/README.md
+++ b/README.md
@@ -18,15 +18,42 @@ BinjaLattice is a secure communication protocol for Binary Ninja that enables in
 
 ## Installation
 
-1. Copy `lattice_server_plugin.py` to your Binary Ninja plugins directory:
+### Windows (Automated)
+
+Run the PowerShell installer for a one-shot setup:
+
+```powershell
+.\scripts\install_windows.ps1
+```
+
+This will:
+- Install the plugin to `%APPDATA%\Binary Ninja\plugins\`
+- Create a Python virtual environment (`.venv`)
+- Install all dependencies
+- Output a ready-to-use MCP configuration
+
+### Manual Installation (All Platforms)
+
+1. Copy `plugin/lattice_server_plugin.py` to your Binary Ninja plugins directory:
    - Linux: `~/.binaryninja/plugins/`
    - macOS: `~/Library/Application Support/Binary Ninja/plugins/`
    - Windows: `%APPDATA%\Binary Ninja\plugins\`
 
-2. Create a virtual environment `pip -m venv venv-test` (or your preferred dependency manager)
+2. Create a virtual environment:
+   ```bash
+   python -m venv .venv
+   ```
 
-3. Activate your virtual environment and install required Python dependencies:
-   - Install with: `pip install -r requirements.txt` (or your preferred method)
+3. Activate and install dependencies:
+   ```bash
+   # Linux/macOS
+   source .venv/bin/activate
+   
+   # Windows
+   .venv\Scripts\activate
+   
+   pip install -r requirements.txt
+   ```
 
 ## Usage
 
@@ -37,13 +64,13 @@ BinjaLattice is a secure communication protocol for Binary Ninja that enables in
 3. The server will start and display the API key in the log console
 4. Set the API key as the `BNJLAT` environment variable in your MCP configuration
 
-Example MCP configuration (`mcp.json`) from Cursor:
+Example MCP configuration (`mcp.json`):
 ```json
 {
     "mcpServers": {
       "binja-lattice-mcp": {
-        "command": "/path/to/venv/bin/python",
-        "args": ["/path/to/mcp_server.py"],
+        "command": "/path/to/BinjaLattice/.venv/bin/python",
+        "args": ["/path/to/BinjaLattice/mcp_server.py"],
         "env": {
             "BNJLAT": "your_api_key_here"
         }
@@ -51,6 +78,23 @@ Example MCP configuration (`mcp.json`) from Cursor:
     }
 }
 ```
+
+On Windows, use backslashes:
+```json
+{
+    "mcpServers": {
+      "binja-lattice-mcp": {
+        "command": "C:\\path\\to\\BinjaLattice\\.venv\\Scripts\\python.exe",
+        "args": ["C:\\path\\to\\BinjaLattice\\mcp_server.py"],
+        "env": {
+            "BNJLAT": "your_api_key_here"
+        }
+      }
+    }
+}
+```
+
+> **Tip**: The Windows installer outputs a ready-to-paste configuration with the correct paths.
 
 ### Available MCP Tools
 

--- a/scripts/install_windows.ps1
+++ b/scripts/install_windows.ps1
@@ -1,0 +1,191 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    BinjaLattice Windows Installer
+
+.DESCRIPTION
+    Complete one-shot installer that:
+    1. Installs the Binary Ninja plugin to the correct directory
+    2. Creates a Python virtual environment for the MCP server
+    3. Installs all dependencies
+    4. Outputs ready-to-use MCP configuration
+    
+    Plugin install path (per Binary Ninja docs):
+    https://docs.binary.ninja/guide/plugins.html
+    Windows: %APPDATA%\Binary Ninja\plugins
+
+.EXAMPLE
+    .\install_windows.ps1
+    
+.EXAMPLE
+    .\install_windows.ps1 -Force
+#>
+
+param(
+    [switch]$Force
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host ""
+Write-Host "============================================" -ForegroundColor Cyan
+Write-Host "   BinjaLattice Windows Installer" -ForegroundColor Cyan
+Write-Host "============================================" -ForegroundColor Cyan
+Write-Host ""
+
+# Get paths
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = Split-Path -Parent $ScriptDir
+$PluginSource = Join-Path $RepoRoot "plugin\lattice_server_plugin.py"
+$McpServerPath = Join-Path $RepoRoot "mcp_server.py"
+$RequirementsPath = Join-Path $RepoRoot "requirements.txt"
+$VenvPath = Join-Path $RepoRoot ".venv"
+$VenvPython = Join-Path $VenvPath "Scripts\python.exe"
+
+# Binary Ninja plugins directory per official documentation
+$BNPluginsDir = Join-Path $env:APPDATA "Binary Ninja\plugins"
+
+# ============================================
+# STEP 1: Validate environment
+# ============================================
+Write-Host "[STEP 1/4] Validating environment..." -ForegroundColor Cyan
+
+# Check Python is available
+$pythonCmd = Get-Command python -ErrorAction SilentlyContinue
+if (-not $pythonCmd) {
+    Write-Host "[ERROR] Python not found in PATH." -ForegroundColor Red
+    Write-Host "        Please install Python 3.8+ and ensure it's in your PATH." -ForegroundColor Yellow
+    Read-Host "Press Enter to exit"
+    exit 1
+}
+
+$pythonVersion = & python --version 2>&1
+Write-Host "          Found: $pythonVersion" -ForegroundColor Green
+
+# Check Binary Ninja plugins directory
+if (-not (Test-Path $BNPluginsDir)) {
+    Write-Host "[ERROR] Binary Ninja plugins directory not found at:" -ForegroundColor Red
+    Write-Host "        $BNPluginsDir" -ForegroundColor Yellow
+    Write-Host ""
+    Write-Host "Please ensure Binary Ninja is installed and has been run at least once." -ForegroundColor Yellow
+    Read-Host "Press Enter to exit"
+    exit 1
+}
+Write-Host "          Found Binary Ninja plugins dir" -ForegroundColor Green
+
+# Check plugin source exists
+if (-not (Test-Path $PluginSource)) {
+    Write-Host "[ERROR] Plugin file not found. Run from BinjaLattice repo." -ForegroundColor Red
+    Read-Host "Press Enter to exit"
+    exit 1
+}
+Write-Host ""
+
+# ============================================
+# STEP 2: Install Binary Ninja plugin
+# ============================================
+Write-Host "[STEP 2/4] Installing Binary Ninja plugin..." -ForegroundColor Cyan
+
+$PluginDest = Join-Path $BNPluginsDir "lattice_server_plugin.py"
+if ((Test-Path $PluginDest) -and -not $Force) {
+    Write-Host "          Plugin already exists." -ForegroundColor Yellow
+    $response = Read-Host "          Overwrite? (y/N)"
+    if ($response -ne 'y' -and $response -ne 'Y') {
+        Write-Host "          Skipping plugin install." -ForegroundColor Yellow
+    }
+    else {
+        Copy-Item -Path $PluginSource -Destination $PluginDest -Force
+        Write-Host "          Plugin updated." -ForegroundColor Green
+    }
+}
+else {
+    Copy-Item -Path $PluginSource -Destination $PluginDest -Force
+    Write-Host "          Plugin installed to:" -ForegroundColor Green
+    Write-Host "          $PluginDest" -ForegroundColor White
+}
+Write-Host ""
+
+# ============================================
+# STEP 3: Create virtual environment
+# ============================================
+Write-Host "[STEP 3/4] Setting up Python virtual environment..." -ForegroundColor Cyan
+
+if ((Test-Path $VenvPath) -and -not $Force) {
+    Write-Host "          Virtual environment already exists at .venv" -ForegroundColor Yellow
+    $response = Read-Host "          Recreate? (y/N)"
+    if ($response -eq 'y' -or $response -eq 'Y') {
+        Remove-Item -Recurse -Force $VenvPath
+        & python -m venv $VenvPath
+        Write-Host "          Virtual environment recreated." -ForegroundColor Green
+    }
+}
+else {
+    if (Test-Path $VenvPath) {
+        Remove-Item -Recurse -Force $VenvPath
+    }
+    & python -m venv $VenvPath
+    Write-Host "          Virtual environment created at .venv" -ForegroundColor Green
+}
+Write-Host ""
+
+# ============================================
+# STEP 4: Install dependencies
+# ============================================
+Write-Host "[STEP 4/4] Installing dependencies..." -ForegroundColor Cyan
+
+try {
+    & $VenvPython -m pip install --upgrade pip --quiet 2>&1 | Out-Null
+    & $VenvPython -m pip install mcp requests --quiet 2>&1 | Out-Null
+    Write-Host "          Dependencies installed (mcp, requests)" -ForegroundColor Green
+}
+catch {
+    Write-Host "[ERROR] Failed to install dependencies: $_" -ForegroundColor Red
+    Read-Host "Press Enter to exit"
+    exit 1
+}
+Write-Host ""
+
+# ============================================
+# SUCCESS - Output configuration
+# ============================================
+Write-Host "============================================" -ForegroundColor Green
+Write-Host "   Installation Complete!" -ForegroundColor Green
+Write-Host "============================================" -ForegroundColor Green
+Write-Host ""
+Write-Host "Binary Ninja Plugin:" -ForegroundColor Cyan
+Write-Host "  Installed to: $PluginDest" -ForegroundColor White
+Write-Host ""
+Write-Host "MCP Server:" -ForegroundColor Cyan
+Write-Host "  Python: $VenvPython" -ForegroundColor White
+Write-Host "  Server: $McpServerPath" -ForegroundColor White
+Write-Host ""
+Write-Host "Add this to your MCP configuration (mcp.json):" -ForegroundColor Yellow
+Write-Host ""
+
+# Output JSON config with escaped backslashes for Windows paths
+$escapedPython = $VenvPython -replace '\\', '\\'
+$escapedServer = $McpServerPath -replace '\\', '\\'
+
+Write-Host @"
+{
+  "mcpServers": {
+    "binja-lattice-mcp": {
+      "command": "$escapedPython",
+      "args": ["$escapedServer"],
+      "env": {
+        "BNJLAT": "YOUR_API_KEY_HERE"
+      }
+    }
+  }
+}
+"@ -ForegroundColor Gray
+
+Write-Host ""
+Write-Host "Next steps:" -ForegroundColor Cyan
+Write-Host "  1. Restart Binary Ninja"
+Write-Host "  2. Open a binary file"
+Write-Host "  3. Plugins > Start Lattice Protocol Server"
+Write-Host "  4. Copy the API key from the log console"
+Write-Host "  5. Replace YOUR_API_KEY_HERE in your mcp.json"
+Write-Host ""
+Read-Host "Press Enter to exit"


### PR DESCRIPTION
Closes #2

Adds a one-shot PowerShell installer ( install_windows.ps1) that:

Installs the Binary Ninja plugin to the correct path (%APPDATA%\Binary Ninja\plugins\)
Creates a Python virtual environment in the repo
Installs all dependencies
Outputs a ready-to-paste MCP configuration with correct paths
Also updated the README with Windows-specific installation instructions and MCP config examples.